### PR TITLE
Rebuild for consistency across platforms

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+channels:
+  jcmorin-ana-org: aws
+
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7d4e2f1df43a1198ed4d95870ac10eb9fba517ab0aac988e6f940aaa61052a9a
 
 build:
-  number: 5
+  number: 6
   run_exports:
     - {{ pin_subpackage("aws-c-event-stream", max_pin="x.x.x") }}
 
@@ -21,8 +21,11 @@ requirements:
     - {{ compiler('cxx') }}
     - ninja
   host:
-    - aws-c-common
-    - aws-checksums
+    - aws-c-common 0.6.8
+    - aws-checksums 0.1.11
+  run:
+    - aws-c-common >=0.6.8,<0.6.9.0a0
+    - aws-checksums >=0.1.11,<0.1.12.0a0
 
 test:
   commands:
@@ -35,7 +38,12 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: C99 implementation of the vnd.amazon.eventstream content-type.
+  description: C99 implementation of the vnd.amazon.eventstream content-type.
+  doc_url: https://github.com/awslabs/aws-c-event-stream
+  dev_url: https://github.com/awslabs/aws-c-event-stream
 
 extra:
+  skip-lints:
+    - missing_tests
   recipe-maintainers:
     - xhochy


### PR DESCRIPTION
On linux-64, it was depending on `aws-c-common >=0.4.57,<0.4.58.0a0` and `aws-checksums >=0.1.9,<0.1.10.0a0` while on osx-arm64 it was depending on `aws-c-common >=0.6.8,<0.6.9.0a0` and `aws-checksums >=0.1.11,<0.1.12.0a0`.

This is creating conflicts when trying to rebuild `aws-sdk-cpp`.

Depends on:
* https://github.com/AnacondaRecipes/aws-c-common-feedstock/pull/16
* https://github.com/AnacondaRecipes/aws-checksums-feedstock/pull/2