### PR TITLE
update to 0.2.15

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/aws-c-common-feedstock/pr17/fdb0797
-  - https://staging.continuum.io/prefect/fs/aws-checksums-feedstock/pr3/28cac8c
+  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr1/f0821de

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr1/f0821de
-  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr1/ea61a89
-  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr1/ade4da2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr1/f0821de
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr1/ea61a89
+  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr1/ade4da2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-c-common-feedstock/pr17/fdb0797
+  - https://staging.continuum.io/prefect/fs/aws-checksums-feedstock/pr3/28cac8c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-event-stream" %}
-{% set version = "0.1.6" %}
+{% set version = "0.2.15" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 7d4e2f1df43a1198ed4d95870ac10eb9fba517ab0aac988e6f940aaa61052a9a
+  sha256: 4ff2ada07ede3c6afa4b8e6e20de541e717038307f29b38c27efa7c4d875ee26
 
 build:
-  number: 6
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-event-stream", max_pin="x.x.x") }}
 
@@ -21,11 +21,11 @@ requirements:
     - {{ compiler('cxx') }}
     - ninja
   host:
-    - aws-c-common 0.6.8
-    - aws-checksums 0.1.11
+    - aws-c-common 0.8.5
+    - aws-checksums 0.1.13
   run:
-    - aws-c-common >=0.6.8,<0.6.9.0a0
-    - aws-checksums >=0.1.11,<0.1.12.0a0
+    - aws-c-common >=0.8.5,<0.8.6.0a0
+    - aws-checksums >=0.1.13,<0.1.14.0a0
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,13 +19,15 @@ requirements:
     - cmake
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - ninja
+    - ninja-base
   host:
     - aws-c-common 0.8.5
     - aws-checksums 0.1.13
+    - aws-c-io 0.13.10
   run:
     - aws-c-common >=0.8.5,<0.8.6.0a0
     - aws-checksums >=0.1.13,<0.1.14.0a0
+    - aws-c-io >=0.13.10,<0.14.10.0a0
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,9 @@ requirements:
     - aws-checksums 0.1.13
     - aws-c-io 0.13.10
   run:
-    - aws-c-common >=0.8.5,<0.8.6.0a0
-    - aws-checksums >=0.1.13,<0.1.14.0a0
-    - aws-c-io >=0.13.10,<0.14.10.0a0
+    - aws-c-common # pinning by run_exports
+    - aws-checksums # pinning by run_exports
+    - aws-c-io # pinning by run_exports
 
 test:
   commands:


### PR DESCRIPTION
aws-c-event-stream 0.2.15

Destination channel: defaults

Links
[{ticket_number}](https://anaconda.atlassian.net/browse/PKG-3913)
[Upstream repository](https://github.com/awslabs/aws-c-event-stream/releases/tag/v0.2.15)
dependency for aws-sdk-cpp 1.10.55 -> arrow-cpp 14.0.1 -> pyarrow 14.0.1 which would address CVE
