### PR TITLE
aws-c-event-stream 0.5.4 rebuild

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,8 +7,13 @@ cmake -G "Ninja" ^
       -DCMAKE_INSTALL_LIBDIR=lib ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DBUILD_SHARED_LIBS=ON ^
+      -DENABLE_TESTING=ON ^
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON ^
       ..
 if errorlevel 1 exit 1
 
-ninja install
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+ctest --output-on-failure
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,9 +8,12 @@ cmake ${CMAKE_ARGS} -GNinja \
   -DCMAKE_PREFIX_PATH=$PREFIX \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_INSTALL_LIBDIR=lib \
-  -DENABLE_TESTING=OFF \
+  -DENABLE_TESTING=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
   ..
-ninja install
+cmake --build . --config Release --target install
+
+ctest --output-on-failure -j${CPU_COUNT}
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cef8b78e362836d15514110fb43a0a0c7a86b0a210d5fe25fd248a82027a7272
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-c-event-stream", max_pin="x.x.x") }}
 
@@ -21,7 +21,7 @@ requirements:
     - {{ compiler('cxx') }}
     - ninja-base
   host:
-    - aws-c-common 0.11.1
+    - aws-c-common 0.12.3
     - aws-checksums 0.2.3
     - aws-c-io 0.17.0
   run:


### PR DESCRIPTION
aws-c-event-stream 0.5.4 

**Destination channel:** Defaults

### Links

- [PKG-8627]
- dev_url:        https://github.com/awslabs/aws-c-event-stream
- conda_forge:    https://github.com/conda-forge/aws-c-event-stream-feedstock
- pypi:           https://pypi.org/project/aws-c-event-stream/0.5.4
- pypi inspector: https://inspector.pypi.io/project/aws-c-event-stream/0.5.4/

### Explanation of changes:

- rebuild due to new dependency verion


[PKG-8627]: https://anaconda.atlassian.net/browse/PKG-8627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ