### PR TITLE
Update version to 0.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-event-stream" %}
-{% set version = "0.5.9" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: e9371ffe050c24ca4eda439d58a06285db88b550e9cbec006d6ea21db02d424a
+  sha256: af3cd291d831b5fd65f789b7b9d34d856c6a3a5f6f5eb03bc23cffd1792d25e9
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - ninja-base
   host:
     - aws-c-common 0.12.6
-    - aws-checksums 0.2.8
+    - aws-checksums 0.2.10
     - aws-c-io 0.23.3
 
 test:


### PR DESCRIPTION
aws-c-event-stream 0.6.0

**Destination channel:** defaults

### Links

- [PKG-13175](https://anaconda.atlassian.net/browse/PKG-13175) 
- [Upstream repository](https://github.com/awslabs/aws-c-event-stream/tree/v0.6.0)

### Explanation of changes:
- New version number
- update dependency


[PKG-13175]: https://anaconda.atlassian.net/browse/PKG-13175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ