### PR TITLE
aws-c-event-stream 0.6.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-event-stream" %}
-{% set version = "0.6.0" %}
+{% set version = "0.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: af3cd291d831b5fd65f789b7b9d34d856c6a3a5f6f5eb03bc23cffd1792d25e9
+  sha256: fc10eee55d752a8fb258ebd813df48c39c31cd1bd5d8377088937bc7568693b8
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   host:
     - aws-c-common 0.12.6
     - aws-checksums 0.2.10
-    - aws-c-io 0.23.3
+    - aws-c-io 0.26.3
 
 test:
   commands:


### PR DESCRIPTION
aws-c-event-stream 0.6.1 

**Destination channel:** Defaults

### Links

- [PKG-13594]
- dev_url:        https://github.com/awslabs/aws-c-event-stream
- conda_forge:    https://github.com/conda-forge/aws-c-event-stream-feedstock
- pypi:           https://pypi.org/project/aws-c-event-stream/0.6.1
- pypi inspector: https://inspector.pypi.io/project/aws-c-event-stream/0.6.1

### Explanation of changes:

- new version number


[PKG-13594]: https://anaconda.atlassian.net/browse/PKG-13594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ