### PR TITLE
aws-c-event-stream 0.7.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "aws-c-event-stream" %}
-{% set version = "0.6.1" %}
+{% set version = "0.7.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: fc10eee55d752a8fb258ebd813df48c39c31cd1bd5d8377088937bc7568693b8
+  sha256: 334b2abfe0cb5c68d79d52525598fdd5f6052b93a17a78a4b1ada7fa1be252c0
 
 build:
   number: 0
@@ -20,8 +20,9 @@ requirements:
     - {{ compiler('c') }}
     - cmake >=3.9
     - ninja-base
+    - zlib
   host:
-    - aws-c-common 0.12.6
+    - aws-c-common 0.14.0
     - aws-checksums 0.2.10
     - aws-c-io 0.26.3
 


### PR DESCRIPTION
aws-c-event-stream 0.7.1 

**Destination channel:** Defaults

### Links

- [PKG-15440]
- dev_url:        https://github.com/awslabs/aws-c-event-stream/tree/v0.7.1
- conda_forge:    https://github.com/conda-forge/aws-c-event-stream-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new version number


[PKG-15440]: https://anaconda.atlassian.net/browse/PKG-15440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ